### PR TITLE
Don't fail easily

### DIFF
--- a/src/XmlDocs/DocumentationFile.cs
+++ b/src/XmlDocs/DocumentationFile.cs
@@ -45,7 +45,7 @@ public class DocumentationFile : DocumentationElement
             throw new ArgumentException("Value must not be null or whitespace", nameof(filePath));
 
         var xml = File.ReadAllText(filePath);
-        return FromXml(xml); ;
+        return FromXml(xml);
     }
 
     /// <summary>

--- a/src/XmlDocs/_Model/TextBlock.cs
+++ b/src/XmlDocs/_Model/TextBlock.cs
@@ -78,31 +78,45 @@ public class TextBlock : TextElement, IEquatable<TextBlock>
 
         foreach (var node in xml.Nodes())
         {
-            if (node is XText textNode)
+            TextElement? returnElement = null;
+
+            try
             {
-                var text = XmlContentHelper.TrimText(textNode.Value, indent);
-                if (!String.IsNullOrEmpty(text))
-                    yield return new PlainTextElement(text);
-            }
-            else if (node is XElement element)
-            {
-                //TODO: <a> tag (supported by Visual Studio)
-                yield return element.Name.LocalName switch
+                if (node is XText textNode)
                 {
-                    "para" => ParagraphElement.FromXml(element),
-                    "paramref" => ParameterReferenceElement.FromXml(element),
-                    "typeparamref" => TypeParameterReferenceElement.FromXml(element),
-                    "code" => CodeElement.FromXml(element),
-                    "c" => CElement.FromXml(element),
-                    "see" => SeeElement.FromXml(element),
-                    "list" => ListElement.FromXml(element),
-                    "em" => EmphasisElement.FromXml(element),
-                    "i" => IdiomaticElement.FromXml(element),
-                    "b" => BoldElement.FromXml(element),
-                    "strong" => StrongElement.FromXml(element),
-                    "br" => LineBreakElement.FromXml(element),
-                    _ => new UnrecognizedTextElement(element)
-                };
+                    var text = XmlContentHelper.TrimText(textNode.Value, indent);
+                    if (!String.IsNullOrEmpty(text))
+                        returnElement = new PlainTextElement(text);
+                }
+                else if (node is XElement element)
+                {
+                    //TODO: <a> tag (supported by Visual Studio)
+                    returnElement = element.Name.LocalName switch
+                    {
+                        "para" => ParagraphElement.FromXml(element),
+                        "paramref" => ParameterReferenceElement.FromXml(element),
+                        "typeparamref" => TypeParameterReferenceElement.FromXml(element),
+                        "code" => CodeElement.FromXml(element),
+                        "c" => CElement.FromXml(element),
+                        "see" => SeeElement.FromXml(element),
+                        "list" => ListElement.FromXml(element),
+                        "em" => EmphasisElement.FromXml(element),
+                        "i" => IdiomaticElement.FromXml(element),
+                        "b" => BoldElement.FromXml(element),
+                        "strong" => StrongElement.FromXml(element),
+                        "br" => LineBreakElement.FromXml(element),
+                        _ => new UnrecognizedTextElement(element)
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            
+            if (returnElement != null)
+            {
+                yield return returnElement;
             }
         }
     }

--- a/src/XmlDocs/_Model/_Blocks/ListElement.cs
+++ b/src/XmlDocs/_Model/_Blocks/ListElement.cs
@@ -20,7 +20,7 @@ public abstract class ListElement : BlockElement
     {
         xml.EnsureNameIs("list");
 
-        var listType = xml.RequireAttribute("type").RequireValue();
+        var listType = xml.Attribute("type")?.Value ?? "bullet";
 
         if (StringComparer.OrdinalIgnoreCase.Equals("bullet", listType))
         {


### PR DESCRIPTION
Thanks for your nice library, 
I had searched for quite a while and yours was the only one which is done in a similar way like I had in mind. I'm using it to amend our OpenAPI schema generation with information from XmlDoc comments and it is very suitable for this purpose, except one thing: you are throwing exceptions quite easily, which prevents a DocumentElement form being loaded.
While I could have just fixed the XmlDoc, there's two problems with this:

1. As it terminates on the first exception, I would have been forced to run it again and again, each time just being able to fix the one issue found, then needing to do another run for (potentially) finding the next isssue
2. Having tens of thousands of members makes it likely to happen that a developer makes a mistake without noticing, which would then cause the doc comments generation to fail on the next (automated) build. 

Our xmldoc comments are processed by:

- the C# compiler
- GhostDoc (for preview in VS)
- ReSharper
- StyleCop for Resharper
- DocFx

None of these had ever complained about things like a missing type attribute on a list element (for example).

This PR is merely to show what I had to do to achieve a higher tolerance to issues in xmlDoc contents, so feel free to close it. If you want to do something about it, you'll probably do it in a better way (like storing exceptions in a context object, so that it's possible to present/provide them as "parsing errors" at the end of building the DocumentationFile (or a subtree). 

Thanks
